### PR TITLE
Fix conditional expression and add tests

### DIFF
--- a/src/python/qeforest/simulator.py
+++ b/src/python/qeforest/simulator.py
@@ -3,9 +3,14 @@ import os
 import numpy as np
 from zquantum.core.interfaces.backend import QuantumSimulator
 from zquantum.core.circuit import save_circuit
-from zquantum.core.measurement import (load_wavefunction, load_expectation_values, sample_from_wavefunction,
-                                        ExpectationValues, expectation_values_to_real,
-                                        Measurements)
+from zquantum.core.measurement import (
+    load_wavefunction,
+    load_expectation_values,
+    sample_from_wavefunction,
+    ExpectationValues,
+    expectation_values_to_real,
+    Measurements,
+)
 from forestopenfermion import qubitop_to_pyquilpauli
 from pyquil.api import WavefunctionSimulator, get_qc
 
@@ -17,7 +22,7 @@ class ForestSimulator(QuantumSimulator):
         self.device_name = device_name
 
     def run_circuit_and_measure(self, circuit, **kwargs):
-        '''
+        """
         Run a circuit and measure a certain number of bitstrings. Note: the number
         of bitstrings measured is derived from self.n_samples
 
@@ -25,7 +30,7 @@ class ForestSimulator(QuantumSimulator):
             circuit (zquantum.core.circuit.Circuit): the circuit to prepare the state
         Returns:
             a list of bitstrings (a list of tuples)
-        '''
+        """
         cxn = get_forest_connection(self.device_name)
         bitstrings = cxn.run_and_measure(circuit.to_pyquil(), trials=self.n_samples)
         if isinstance(bitstrings, dict):
@@ -36,7 +41,7 @@ class ForestSimulator(QuantumSimulator):
         return Measurements(bitstrings)
 
     def get_expectation_values(self, circuit, qubit_operator, **kwargs):
-        if self.device_name == 'wavefunction-simulator' and self.n_samples==None:
+        if self.device_name == "wavefunction-simulator" and self.n_samples == None:
             return self.get_exact_expectation_values(circuit, qubit_operator, **kwargs)
         else:
             measurements = self.run_circuit_and_measure(circuit, nthreads=self.nthreads)
@@ -44,10 +49,13 @@ class ForestSimulator(QuantumSimulator):
 
             expectation_values = expectation_values_to_real(expectation_values)
             return expectation_values
-            
+
     def get_exact_expectation_values(self, circuit, qubit_operator, **kwargs):
-        if self.device_name != 'wavefunction-simulator' and self.n_samples!=None:
-            raise Exception("Exact expectation values work only for the wavefunction simulator and n_samples equal to None.")
+        if self.device_name != "wavefunction-simulator" or self.n_samples != None:
+            raise Exception(
+                f"""To compute exact expectation values, (i) the device name must be "wavefunction-simulator" and (ii) n_samples 
+                    must be None. The device name is currently {self.device_name} and n_samples is {self.n_samples}."""
+            )
         cxn = get_forest_connection(self.device_name)
 
         # Pyquil does not support PauliSums with no terms.
@@ -55,10 +63,18 @@ class ForestSimulator(QuantumSimulator):
             return ExpectationValues(np.zeros((0,)))
 
         pauli_sum = qubitop_to_pyquilpauli(qubit_operator)
-        expectation_values = np.real(cxn.expectation(circuit.to_pyquil(), pauli_sum.terms))
-        
+        expectation_values = np.real(
+            cxn.expectation(circuit.to_pyquil(), pauli_sum.terms)
+        )
+
         if expectation_values.shape[0] != len(pauli_sum):
-            raise(RuntimeError("Expected {} expectation values but received {}.".format(len(pauli_sum), expectation_values.shape[0])))
+            raise (
+                RuntimeError(
+                    "Expected {} expectation values but received {}.".format(
+                        len(pauli_sum), expectation_values.shape[0]
+                    )
+                )
+            )
         return ExpectationValues(expectation_values)
 
     def get_wavefunction(self, circuit):
@@ -68,15 +84,15 @@ class ForestSimulator(QuantumSimulator):
 
 
 def get_forest_connection(device_name):
-    '''Get a connection to a forest backend
+    """Get a connection to a forest backend
 
     Args:
         device_name (string): the device to connect to
 
     Returns:
         A connection to either a pyquil simulator or a QPU
-    '''
-    if device_name == 'wavefunction-simulator':
+    """
+    if device_name == "wavefunction-simulator":
         return WavefunctionSimulator()
     else:
         return get_qc(device_name)

--- a/src/python/qeforest/simulator.py
+++ b/src/python/qeforest/simulator.py
@@ -22,8 +22,7 @@ class ForestSimulator(QuantumSimulator):
         self.device_name = device_name
 
     def run_circuit_and_measure(self, circuit, **kwargs):
-        """
-        Run a circuit and measure a certain number of bitstrings. Note: the number
+        """Run a circuit and measure a certain number of bitstrings. Note: the number
         of bitstrings measured is derived from self.n_samples
 
         Args:
@@ -41,7 +40,7 @@ class ForestSimulator(QuantumSimulator):
         return Measurements(bitstrings)
 
     def get_expectation_values(self, circuit, qubit_operator, **kwargs):
-        if self.device_name == "wavefunction-simulator" and self.n_samples == None:
+        if self.device_name == "wavefunction-simulator" and self.n_samples is None:
             return self.get_exact_expectation_values(circuit, qubit_operator, **kwargs)
         else:
             measurements = self.run_circuit_and_measure(circuit, nthreads=self.nthreads)
@@ -51,7 +50,7 @@ class ForestSimulator(QuantumSimulator):
             return expectation_values
 
     def get_exact_expectation_values(self, circuit, qubit_operator, **kwargs):
-        if self.device_name != "wavefunction-simulator" or self.n_samples != None:
+        if self.device_name != "wavefunction-simulator" or self.n_samples is not None:
             raise Exception(
                 f"""To compute exact expectation values, (i) the device name must be "wavefunction-simulator" and (ii) n_samples 
                     must be None. The device name is currently {self.device_name} and n_samples is {self.n_samples}."""

--- a/src/python/qeforest/simulator_test.py
+++ b/src/python/qeforest/simulator_test.py
@@ -8,13 +8,31 @@ from .simulator import ForestSimulator
 from pyquil import Program
 from pyquil.gates import H, CNOT, RX, CZ, X
 
-class TestForest(unittest.TestCase, QuantumSimulatorTests):
 
+class TestForest(unittest.TestCase, QuantumSimulatorTests):
     def setUp(self):
         self.wf_simulator = ForestSimulator("wavefunction-simulator")
         self.sampling_simulator = ForestSimulator("3q-qvm", n_samples=10000)
         self.noisy_simulator = ForestSimulator("3q-noisy-qvm", n_samples=10000)
 
         # Inherited tests
-        self.backends = [self.sampling_simulator, self.noisy_simulator, self.wf_simulator]
+        self.backends = [
+            self.sampling_simulator,
+            self.noisy_simulator,
+            self.wf_simulator,
+        ]
         self.wf_simulators = [self.wf_simulator]
+
+    def test_exact_expectation_values_without_wavefunction_simulator(self):
+        self.sampling_simulator.n_samples = None
+        operator = QubitOperator("Z0 Z1")
+        circuit = Circuit(Program([X(0), X(1)]))
+        with self.assertRaises(Exception):
+            self.sampling_simulator.get_exact_expectation_values(circuit, operator)
+
+    def test_exact_expectation_values_with_n_samples(self):
+        self.wf_simulator.n_samples = 1000
+        operator = QubitOperator("Z0 Z1")
+        circuit = Circuit(Program([X(0), X(1)]))
+        with self.assertRaises(Exception):
+            self.wf_simulator.get_exact_expectation_values(circuit, operator)


### PR DESCRIPTION
This PR fixes a minor bug in a conditional in the `get_exact_expectation_values` method. It is also reformatted with black. 

The relevant changes are [here](https://github.com/zapatacomputing/qe-forest/pull/6/files#diff-62545577c99b448461de2f826d83d92aR54).