### PR TITLE
Upgrade to pyquil v2.25.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,6 @@ setuptools.setup(
     install_requires=[
         "z-quantum-core",
         "forestopenfermion @ http://github.com/zapatacomputing/forest-openfermion/tarball/fast-op-conversion",
+        "pyquil>=2.25.0"
     ],
 )


### PR DESCRIPTION
The CI/CD PR pipeline was failing, apparently because of a 1 second timeout that pyquil uses when checking the version of `quilc`. The changes to timeout settings in [pyquil v2.25.0](https://github.com/rigetti/pyquil/releases/tag/v2.25.0) seem to have fixed this.