### PR TITLE
Migrate to new circuits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,7 @@ setuptools.setup(
         "z-quantum-core",
         "pyquil>=2.25.0",
     ],
+    extras_require={
+        "dev": ["pytest"],
+    },
 )

--- a/src/python/qeforest/simulator.py
+++ b/src/python/qeforest/simulator.py
@@ -1,20 +1,14 @@
 import errno
-import os
 import socket
 import subprocess
 
 import numpy as np
 from pyquil.api import WavefunctionSimulator, get_qc
 from zquantum.core.circuit import Circuit as OldCircuit
-from zquantum.core.circuit import save_circuit
 from zquantum.core.interfaces.backend import QuantumSimulator
 from zquantum.core.measurement import (
     ExpectationValues,
     Measurements,
-    expectation_values_to_real,
-    load_expectation_values,
-    load_wavefunction,
-    sample_from_wavefunction,
 )
 from zquantum.core.openfermion import qubitop_to_pyquilpauli
 from zquantum.core.wip.circuits import export_to_pyquil, new_circuit_from_old_circuit

--- a/src/python/qeforest/simulator.py
+++ b/src/python/qeforest/simulator.py
@@ -51,16 +51,15 @@ class ForestSimulator(QuantumSimulator):
         s.close()
 
     @compatible_with_old_type(
-        old_type=OldCircuit,
-        translate_old_to_wip=new_circuit_from_old_circuit
+        old_type=OldCircuit, translate_old_to_wip=new_circuit_from_old_circuit
     )
     def run_circuit_and_measure(self, circuit, n_samples=None, **kwargs):
         """Run a circuit and measure a certain number of bitstrings. Note: the number
         of bitstrings measured is derived from self.n_samples
 
         Args:
-            circuit (zquantum.core.circuit.Circuit): the circuit to prepare the state
-            n_samples (int): The number of samples to measure. If None, then the
+            circuit: the circuit to prepare the state
+            n_samples: The number of samples to measure. If None, then the
                 number of samples is taken from the n_samples attribute.
         Returns:
             a list of bitstrings (a list of tuples)
@@ -78,8 +77,7 @@ class ForestSimulator(QuantumSimulator):
         return Measurements(bitstrings)
 
     @compatible_with_old_type(
-        old_type=OldCircuit,
-        translate_old_to_wip=new_circuit_from_old_circuit
+        old_type=OldCircuit, translate_old_to_wip=new_circuit_from_old_circuit
     )
     def get_exact_expectation_values(self, circuit, qubit_operator, **kwargs):
         self.number_of_jobs_run += 1
@@ -111,8 +109,7 @@ class ForestSimulator(QuantumSimulator):
         return ExpectationValues(expectation_values)
 
     @compatible_with_old_type(
-        old_type=OldCircuit,
-        translate_old_to_wip=new_circuit_from_old_circuit
+        old_type=OldCircuit, translate_old_to_wip=new_circuit_from_old_circuit
     )
     def get_wavefunction(self, circuit):
         super().get_wavefunction(circuit)
@@ -121,11 +118,11 @@ class ForestSimulator(QuantumSimulator):
         return wavefunction
 
 
-def get_forest_connection(device_name):
+def get_forest_connection(device_name: str):
     """Get a connection to a forest backend
 
     Args:
-        device_name (string): the device to connect to
+        device_name: the device to connect to
 
     Returns:
         A connection to either a pyquil simulator or a QPU

--- a/src/python/qeforest/simulator.py
+++ b/src/python/qeforest/simulator.py
@@ -77,7 +77,7 @@ class ForestSimulator(QuantumSimulator):
         self.number_of_jobs_run += 1
         self.number_of_circuits_run += 1
         if self.device_name != "wavefunction-simulator" or self.n_samples is not None:
-            raise Exception(
+            raise RuntimeError(
                 "To compute exact expectation values, (i) the device name must be "
                 "\"wavefunction-simulator\" and (ii) n_samples must be None. The device "
                 f"name is currently {self.device_name} and n_samples is {self.n_samples}."

--- a/src/python/qeforest/simulator.py
+++ b/src/python/qeforest/simulator.py
@@ -67,7 +67,6 @@ class ForestSimulator(QuantumSimulator):
         if isinstance(bitstrings, dict):
             bitstrings = np.vstack([bitstrings[q] for q in sorted(cxn.qubits())]).T
 
-        # Store the bitstrings as a list of tuples, with each tuple representing one bitstring
         bitstrings = [tuple(b) for b in bitstrings.tolist()]
         return Measurements(bitstrings)
 
@@ -79,8 +78,9 @@ class ForestSimulator(QuantumSimulator):
         self.number_of_circuits_run += 1
         if self.device_name != "wavefunction-simulator" or self.n_samples is not None:
             raise Exception(
-                f"""To compute exact expectation values, (i) the device name must be "wavefunction-simulator" and (ii) n_samples 
-                    must be None. The device name is currently {self.device_name} and n_samples is {self.n_samples}."""
+                "To compute exact expectation values, (i) the device name must be "
+                "\"wavefunction-simulator\" and (ii) n_samples must be None. The device "
+                f"name is currently {self.device_name} and n_samples is {self.n_samples}."
             )
         cxn = get_forest_connection(self.device_name)
 
@@ -96,9 +96,8 @@ class ForestSimulator(QuantumSimulator):
         if expectation_values.shape[0] != len(pauli_sum):
             raise (
                 RuntimeError(
-                    "Expected {} expectation values but received {}.".format(
-                        len(pauli_sum), expectation_values.shape[0]
-                    )
+                    f"Expected {len(pauli_sum)} expectation values but received "
+                    f"{expectation_values.shape[0]}."
                 )
             )
         return ExpectationValues(expectation_values)

--- a/src/python/qeforest/simulator.py
+++ b/src/python/qeforest/simulator.py
@@ -77,6 +77,10 @@ class ForestSimulator(QuantumSimulator):
         bitstrings = [tuple(b) for b in bitstrings.tolist()]
         return Measurements(bitstrings)
 
+    @compatible_with_old_type(
+        old_type=OldCircuit,
+        translate_old_to_wip=new_circuit_from_old_circuit
+    )
     def get_exact_expectation_values(self, circuit, qubit_operator, **kwargs):
         self.number_of_jobs_run += 1
         self.number_of_circuits_run += 1
@@ -93,7 +97,7 @@ class ForestSimulator(QuantumSimulator):
 
         pauli_sum = qubitop_to_pyquilpauli(qubit_operator)
         expectation_values = np.real(
-            cxn.expectation(circuit.to_pyquil(), pauli_sum.terms)
+            cxn.expectation(export_to_pyquil(circuit), pauli_sum.terms)
         )
 
         if expectation_values.shape[0] != len(pauli_sum):
@@ -106,10 +110,14 @@ class ForestSimulator(QuantumSimulator):
             )
         return ExpectationValues(expectation_values)
 
+    @compatible_with_old_type(
+        old_type=OldCircuit,
+        translate_old_to_wip=new_circuit_from_old_circuit
+    )
     def get_wavefunction(self, circuit):
         super().get_wavefunction(circuit)
         cxn = get_forest_connection(self.device_name)
-        wavefunction = cxn.wavefunction(circuit.to_pyquil())
+        wavefunction = cxn.wavefunction(export_to_pyquil(circuit))
         return wavefunction
 
 

--- a/src/python/qeforest/simulator.py
+++ b/src/python/qeforest/simulator.py
@@ -1,23 +1,24 @@
+import errno
 import os
+import socket
+import subprocess
 
 import numpy as np
-from zquantum.core.interfaces.backend import QuantumSimulator
-from zquantum.core.circuit import save_circuit
+from pyquil.api import WavefunctionSimulator, get_qc
 from zquantum.core.circuit import Circuit as OldCircuit
+from zquantum.core.circuit import save_circuit
+from zquantum.core.interfaces.backend import QuantumSimulator
 from zquantum.core.measurement import (
-    load_wavefunction,
-    load_expectation_values,
-    sample_from_wavefunction,
     ExpectationValues,
-    expectation_values_to_real,
     Measurements,
+    expectation_values_to_real,
+    load_expectation_values,
+    load_wavefunction,
+    sample_from_wavefunction,
 )
 from zquantum.core.openfermion import qubitop_to_pyquilpauli
-from pyquil.api import WavefunctionSimulator, get_qc
-import subprocess
-import socket, errno
+from zquantum.core.wip.circuits import export_to_pyquil, new_circuit_from_old_circuit
 from zquantum.core.wip.compatibility_tools import compatible_with_old_type
-from zquantum.core.wip.circuits import new_circuit_from_old_circuit, export_to_pyquil
 
 
 class ForestSimulator(QuantumSimulator):


### PR DESCRIPTION
Makes qe-forest work with the new z-quantum-core circuits. 

~Relies on changes from:~
- ~zapatacomputing/z-quantum-core#277~
- ~zapatacomputing/z-quantum-core#278~
~so let's wait until those are merged.~

It's ready!