### PR TITLE
Remove XY from excluded gates

### DIFF
--- a/tests/qeforest/simulator_test.py
+++ b/tests/qeforest/simulator_test.py
@@ -73,4 +73,4 @@ class TestForest(QuantumSimulatorTests):
 
 
 class TestForestGates(QuantumSimulatorGatesTest):
-    gates_to_exclude = ["XY"]
+    pass


### PR DESCRIPTION
Removing XY gate from excluded gates in simulator's test, because XY test cases were fixed in https://github.com/zapatacomputing/z-quantum-core/pull/348